### PR TITLE
fix: adds fallback to effect to prevent crashes on 204

### DIFF
--- a/src/defaults/effect.js
+++ b/src/defaults/effect.js
@@ -25,8 +25,11 @@ const tryParseJSON = (json: string): ?{} => {
 };
 
 const getResponseBody = (res: any): Promise<{} | string> => {
-  const contentType = res.headers.get('content-type');
-  return contentType.indexOf('json') >= 0 ? res.text().then(tryParseJSON) : res.text();
+  const contentType = res.headers.get('content-type') || false;
+  if (contentType) {
+    return contentType.indexOf('json') >= 0 ? res.text().then(tryParseJSON) : res.text();
+  }
+  return null;
 };
 
 export default (effect: any, _action: OfflineAction): Promise<any> => {


### PR DESCRIPTION
This PR addresses the following issue:
- When a response had con `Content-Type` header the `getResponseBody` method raised an error that ended up rejecting the request and dispatching a rollback. This was specially bad when dealing with DELETE operations, because when receiving a 204 http status, no content type was specified.

Solution:
If no content-type header is specified, the `getResponseBody` method will return null.